### PR TITLE
correct warning at line 109

### DIFF
--- a/fmqa/factorization_machine.py
+++ b/fmqa/factorization_machine.py
@@ -106,6 +106,6 @@ class FactorizationMachine(QuadraticLayer):
     def get_bhQ(self):
         """Returns linear and quadratic coefficients.
         """
-        V = nd.zeros(self.V.shape) if self.factorization_size is 0 else self.V.data()
+        V = nd.zeros(self.V.shape) if self.factorization_size == 0 else self.V.data()
         return self.bias.data().asscalar(), self.h.data().asnumpy(), VtoQ(V, nd).asnumpy()
 


### PR DESCRIPTION
~/.local/lib/python3.8/site-packages/fmqa-0.0.1-py3.8.egg/fmqa/factorization_machine.py:109: SyntaxWarning: "is" with a literal. Did you mean "=="?